### PR TITLE
Allow components using forwardRef

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,6 +48,15 @@ function checkForProptypes(path, paramTypeName) {
 
 function setParamsTypeDefinitionFromFunctionType(documentation, path) {
     if (
+        path.parentPath.node.init  &&
+        Array.isArray(path.parentPath.node.init.params) &&
+        path.parentPath.node.init.params.length === 0
+        )
+         {
+        return;
+      }
+      
+    if (
         path.node.type === 'ArrowFunctionExpression' &&
         (
             path.parentPath.node.init &&


### PR DESCRIPTION
### What does this PR do?
- Allow components using forwardRef

### Description of PR
- Components that use React.ForwardRef seem to be caught somewhere with an error because of a `parentPath` check. We want to be able to set param type name for such components.