### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Winner95/typescript-react-function-component-props-handler/security/code-scanning/1](https://github.com/Winner95/typescript-react-function-component-props-handler/security/code-scanning/1)

To fix the flagged issue, add a minimal `permissions` block to restrict the default permissions for the job. As all actions in the workflow need only read access to repository code (for checkout and test), the least privilege configuration is `contents: read`. This can be added at the workflow root (i.e., before `jobs:`) to apply to all jobs (currently only `test`), or inside the individual job for more granularity. To minimize edit scope and maximize clarity, add the `permissions:` block directly below the workflow name and before `on:`. No new methods, imports, or definitions are required; just a YAML edit.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
